### PR TITLE
Fix RoadRunner version format

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -35,7 +35,7 @@ final class Version
     {
         foreach (self::PACKAGE_NAMES as $name) {
             if (InstalledVersions::isInstalled($name)) {
-                return (string)InstalledVersions::getPrettyVersion($name);
+                return \ltrim((string)InstalledVersions::getPrettyVersion($name), 'v');
             }
         }
 


### PR DESCRIPTION
## Actual Behaviour

```php
echo Spiral\RoadRunner\Version::current();
// v2.0.1
```

## Expected Behaviour

```php
echo Spiral\RoadRunner\Version::current();
// 2.0.1
```