### PR TITLE
Feat: add callback to check how many workers are available

### DIFF
--- a/src/Informer/Worker.php
+++ b/src/Informer/Worker.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Informer;
+
+final class Worker
+{
+    /**
+     * @param positive-int $pid process id
+     * @param int $statusCode integer status of the worker
+     * @param int $executions number of worker executions
+     * @param positive-int $createdAt unix nano timestamp of worker creation time
+     * @param positive-int $memoryUsage memory usage in bytes. Values might vary for different operating systems and based on RSS
+     * @param float $cpuUsage how many percent of the CPU time this process uses
+     * @param string $command used in the service plugin and shows a command for the particular service
+     * @param string $status
+     */
+    public function __construct(
+        public int $pid,
+        public int $statusCode,
+        public int $executions,
+        public int $createdAt,
+        public int $memoryUsage,
+        public float $cpuUsage,
+        public string $command,
+        public string $status,
+    ) {
+    }
+}

--- a/src/Informer/Worker.php
+++ b/src/Informer/Worker.php
@@ -14,7 +14,6 @@ final class Worker
      * @param positive-int $memoryUsage memory usage in bytes. Values might vary for different operating systems and based on RSS
      * @param float $cpuUsage how many percent of the CPU time this process uses
      * @param string $command used in the service plugin and shows a command for the particular service
-     * @param string $status
      */
     public function __construct(
         public int $pid,

--- a/src/Informer/Workers.php
+++ b/src/Informer/Workers.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Informer;
+
+final class Workers implements \Countable
+{
+    /**
+     * @param array<Worker> $workers
+     */
+    public function __construct(
+        public array $workers = [],
+    ) {
+    }
+
+    public function count(): int
+    {
+        return \count($this->workers);
+    }
+}

--- a/src/WorkerPool.php
+++ b/src/WorkerPool.php
@@ -34,7 +34,17 @@ final class WorkerPool
      */
     public function countWorkers(string $plugin): int
     {
-        return (int)($this->rpc->call('informer.Workers', $plugin)['workers'] ?? 0);
+        return count($this->getWorkers($plugin));
+    }
+
+    /**
+     * Get the info about running workers for a pool.
+     *
+     * @param non-empty-string $plugin
+     */
+    public function getWorkers(string $plugin): array
+    {
+        return $this->rpc->call('informer.Workers', $plugin)['workers'];
     }
 
     /**

--- a/src/WorkerPool.php
+++ b/src/WorkerPool.php
@@ -28,6 +28,16 @@ final class WorkerPool
     }
 
     /**
+     * Get the worker count for a pool.
+     *
+     * @param non-empty-string $plugin
+     */
+    public function countWorkers(string $plugin): int
+    {
+        return (int)($this->rpc->call('informer.Workers', $plugin)['workers'] ?? 0);
+    }
+
+    /**
      * Remove worker from the pool.
      *
      * @param non-empty-string $plugin

--- a/src/WorkerPool.php
+++ b/src/WorkerPool.php
@@ -42,7 +42,7 @@ final class WorkerPool
     }
 
     /**
-     * Get the worker count for a pool.
+     * Get the number of workers for the pool.
      *
      * @param non-empty-string $plugin
      */
@@ -52,7 +52,7 @@ final class WorkerPool
     }
 
     /**
-     * Get the info about running workers for a pool.
+     * Get the info about running workers for the pool.
      *
      * @param non-empty-string $plugin
      */

--- a/tests/Unit/WorkerPoolTest.php
+++ b/tests/Unit/WorkerPoolTest.php
@@ -35,6 +35,13 @@ final class WorkerPoolTest extends TestCase
         $this->workerPool->addWorker('test');
     }
 
+    public function testCountWorkers(): void
+    {
+        $this->rpc->expects($this->once())->method('call')->with('informer.Workers', 'test');
+
+        $this->workerPool->countWorkers('test');
+    }
+
     public function testRemoveWorker(): void
     {
         $this->rpc->expects($this->once())->method('call')->with('informer.RemoveWorker', 'test');

--- a/tests/Unit/WorkerPoolTest.php
+++ b/tests/Unit/WorkerPoolTest.php
@@ -4,14 +4,28 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Tests\Worker\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use Spiral\Goridge\RPC\Codec\JsonCodec;
 use Spiral\Goridge\RPC\RPCInterface;
+use Spiral\RoadRunner\Informer\Worker;
+use Spiral\RoadRunner\Informer\Workers;
 use Spiral\RoadRunner\WorkerPool;
 
 final class WorkerPoolTest extends TestCase
 {
+    private const EXAMPLE_WORKER = [
+        'pid' => 1,
+        'status' => 1,
+        'numExecs' => 1,
+        'created' => 1,
+        'memoryUsage' => 1,
+        'CPUPercent' => 1.0,
+        'command' => 'test',
+        'statusStr' => 'test',
+    ];
+
     private \PHPUnit\Framework\MockObject\MockObject|RPCInterface $rpc;
     private WorkerPool $workerPool;
 
@@ -23,7 +37,11 @@ final class WorkerPoolTest extends TestCase
         parent::setUp();
 
         $this->rpc = $this->createMock(RPCInterface::class);
-        $this->rpc->expects($this->once())->method('withCodec')->with($this->isInstanceOf(JsonCodec::class))->willReturnSelf();
+        $this->rpc
+            ->expects($this->once())
+            ->method('withCodec')
+            ->with($this->isInstanceOf(JsonCodec::class))
+            ->willReturnSelf();
 
         $this->workerPool = new WorkerPool($this->rpc);
     }
@@ -35,18 +53,28 @@ final class WorkerPoolTest extends TestCase
         $this->workerPool->addWorker('test');
     }
 
-    public function testCountWorkers(): void
+    #[DataProvider('countDataProvider')]
+    public function testCountWorkers(int $expected, array $workers): void
     {
-        $this->rpc->expects($this->once())->method('call')->with('informer.Workers', 'test')->willReturn(['workers' => []]);
+        $this->rpc
+            ->expects($this->once())
+            ->method('call')
+            ->with('informer.Workers', 'test')
+            ->willReturn(['workers' => $workers]);
 
-        $this->workerPool->countWorkers('test');
+        $this->assertSame($expected, $this->workerPool->countWorkers('test'));
     }
 
-    public function testGetWorkers(): void
+    #[DataProvider('getWorkersDataProvider')]
+    public function testGetWorkers(array $expected, array $workers): void
     {
-        $this->rpc->expects($this->once())->method('call')->with('informer.Workers', 'test')->willReturn(['workers' => []]);
+        $this->rpc
+            ->expects($this->once())
+            ->method('call')
+            ->with('informer.Workers', 'test')
+            ->willReturn(['workers' => $workers]);
 
-        $this->workerPool->getWorkers('test');
+        $this->assertEquals(new Workers($expected), $this->workerPool->getWorkers('test'));
     }
 
     public function testRemoveWorker(): void
@@ -54,5 +82,34 @@ final class WorkerPoolTest extends TestCase
         $this->rpc->expects($this->once())->method('call')->with('informer.RemoveWorker', 'test');
 
         $this->workerPool->removeWorker('test');
+    }
+
+    public static function countDataProvider(): \Traversable
+    {
+        yield [0, []];
+        yield [2, [self::EXAMPLE_WORKER, self::EXAMPLE_WORKER]];
+    }
+
+    public static function getWorkersDataProvider(): \Traversable
+    {
+        yield [[], []];
+
+        $workers = \array_map(static function (array $worker): Worker {
+            return new Worker(
+                pid: $worker['pid'],
+                statusCode: $worker['status'],
+                executions: $worker['numExecs'],
+                createdAt:  $worker['created'],
+                memoryUsage: $worker['memoryUsage'],
+                cpuUsage: $worker['CPUPercent'],
+                command: $worker['command'],
+                status: $worker['statusStr'],
+            );
+        }, [
+            self::EXAMPLE_WORKER,
+            self::EXAMPLE_WORKER,
+        ]);
+
+        yield [$workers, [self::EXAMPLE_WORKER, self::EXAMPLE_WORKER]];
     }
 }

--- a/tests/Unit/WorkerPoolTest.php
+++ b/tests/Unit/WorkerPoolTest.php
@@ -37,9 +37,16 @@ final class WorkerPoolTest extends TestCase
 
     public function testCountWorkers(): void
     {
-        $this->rpc->expects($this->once())->method('call')->with('informer.Workers', 'test');
+        $this->rpc->expects($this->once())->method('call')->with('informer.Workers', 'test')->willReturn(['workers' => []]);
 
         $this->workerPool->countWorkers('test');
+    }
+
+    public function testGetWorkers(): void
+    {
+        $this->rpc->expects($this->once())->method('call')->with('informer.Workers', 'test')->willReturn(['workers' => []]);
+
+        $this->workerPool->getWorkers('test');
     }
 
     public function testRemoveWorker(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | #...
| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->

We can add and remove workers, but we don't know how many of them there are in the first place :upside_down_face:

Going by the RPC call https://github.com/roadrunner-server/roadrunner/issues/1728 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced Worker Pool with methods to retrieve worker count and worker information.
	- Implemented classes to manage detailed worker process information and count functionality.
	- Added test methods to validate worker count and retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->