### PR TITLE
Adding `getWorkers` method

### DIFF
--- a/src/Informer/Workers.php
+++ b/src/Informer/Workers.php
@@ -10,8 +10,16 @@ final class Workers implements \Countable
      * @param array<Worker> $workers
      */
     public function __construct(
-        public array $workers = [],
+        private readonly array $workers = [],
     ) {
+    }
+
+    /**
+     * @return array<Worker>
+     */
+    public function getWorkers(): array
+    {
+        return $this->workers;
     }
 
     public function count(): int

--- a/tests/Unit/Informer/WorkersTest.php
+++ b/tests/Unit/Informer/WorkersTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Tests\Worker\Unit\Informer;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\RoadRunner\Informer\Worker;
+use Spiral\RoadRunner\Informer\Workers;
+
+final class WorkersTest extends TestCase
+{
+    public function testGetWorkers(): void
+    {
+        $workers = [
+            new Worker(1, 1, 1, 1, 1, 1.0, 'test1', 'test1'),
+            new Worker(2, 2, 2, 2, 2, 2.0, 'test2', 'test2'),
+        ];
+
+        $this->assertEquals([], (new Workers())->getWorkers());
+        $this->assertEquals($workers, (new Workers($workers))->getWorkers());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ❌

The property with workers is hidden and a getter has been added to obtain it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the security and integrity of the Workers feature by restricting direct access to the workers list.
- **Tests**
	- Added comprehensive tests to ensure the reliability of retrieving workers information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->