### PR TITLE
Added the `codec` parameter to the worker's `respond` method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,9 @@
         "php": ">=8.1",
         "ext-json": "*",
         "ext-sockets": "*",
-        "psr/log": "^2.0|^3.0",
+        "psr/log": "^2.0 || ^3.0",
         "spiral/goridge": "^4.1.0",
-        "spiral/roadrunner": "^2023.1",
+        "spiral/roadrunner": "^2023.1 || ^2024.1",
         "composer-runtime-api": "^2.0"
     },
     "require-dev": {

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -97,8 +97,8 @@ class Worker implements StreamWorkerInterface
 
     /**
      * @param int|null $codec The codec used for encoding the payload header.
-     * Can be {@see Frame::CODEC_PROTO} for Protocol Buffers or {@see Frame::CODEC_JSON} for JSON.
-     * This parameter will be removed in v4.0 and {@see Frame::CODEC_PROTO} will be used by default.
+     *        Can be {@see Frame::CODEC_PROTO} for Protocol Buffers or {@see Frame::CODEC_JSON} for JSON.
+     *        This parameter will be removed in v4.0 and {@see Frame::CODEC_PROTO} will be used by default.
      */
     public function respond(Payload $payload, ?int $codec = null): void
     {

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -95,10 +95,15 @@ class Worker implements StreamWorkerInterface
         return $clone;
     }
 
-    public function respond(Payload $payload): void
+    /**
+     * @param int|null $codec The codec used for encoding the payload header.
+     * Can be {@see Frame::CODEC_PROTO} for Protocol Buffers or {@see Frame::CODEC_JSON} for JSON.
+     * This parameter will be removed in v4.0 and {@see Frame::CODEC_PROTO} will be used by default.
+     */
+    public function respond(Payload $payload, ?int $codec = null): void
     {
         $this->streamMode and ++$this->framesSent;
-        $this->send($payload->body, $payload->header, $payload->eos);
+        $this->send($payload->body, $payload->header, $payload->eos, $codec);
     }
 
     public function error(string $error): void
@@ -198,7 +203,7 @@ class Worker implements StreamWorkerInterface
         return $payload;
     }
 
-    private function send(string $body = '', string $header = '', bool $eos = true): void
+    private function send(string $body = '', string $header = '', bool $eos = true, ?int $codec = null): void
     {
         $frame = new Frame($header . $body, [\strlen($header)]);
 
@@ -208,6 +213,10 @@ class Worker implements StreamWorkerInterface
 
         if ($this->shouldPing) {
             $frame->byte10 |= Frame::BYTE10_PING;
+        }
+
+        if ($codec !== null) {
+            $frame->setFlag($codec);
         }
 
         $this->sendFrame($frame);

--- a/tests/Unit/WorkerTest.php
+++ b/tests/Unit/WorkerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Tests\Worker\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spiral\Goridge\Frame;
+use Spiral\Goridge\RelayInterface;
+use Spiral\RoadRunner\Payload;
+use Spiral\RoadRunner\Worker;
+
+final class WorkerTest extends TestCase
+{
+    #[DataProvider('respondDataProvider')]
+    public function testRespond(int $expectedFlags, ?int $codec): void
+    {
+        $expected = new Frame('Hello World!', [0 => 0], $expectedFlags);
+
+        $relay = $this->createMock(RelayInterface::class);
+        $relay
+            ->expects($this->once())
+            ->method('send')
+            ->with($this->equalTo($expected));
+
+        $worker = new Worker($relay, false);
+
+        $worker->respond(new Payload('Hello World!'), $codec);
+    }
+
+    public static function respondDataProvider(): \Traversable
+    {
+        yield [0, null];
+        yield [Frame::CODEC_PROTO, Frame::CODEC_PROTO];
+        yield [Frame::CODEC_JSON, Frame::CODEC_JSON];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | https://github.com/roadrunner-php/issues/issues/13

### What's changed

This change allows sending the codec in the respond method. For RoadRunner 2024, this is required. In RoadRunner 2023, is optional.

