### PR TITLE
Added RR_VERSION env to Environment class

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -14,10 +14,10 @@ labels: Bug
 
 ### Additional Info
 
-| Q                | A
-|------------------| ---
-| Package Version  | x.y.z <!-- Please set the package version -->
-| PHP version      | x.y.z <!-- Please set the PHP version -->
-| Operating system | Linux <!-- Please set your OS -->
+| Q                | A                                             |
+|------------------|-----------------------------------------------|
+| Package Version  | x.y.z <!-- Please set the package version --> |
+| PHP version      | x.y.z <!-- Please set the PHP version -->     |
+| Operating system | Linux <!-- Please set your OS -->             |
 
 <!-- Optional: any other context about the problem: log messages, screenshots, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-| Q             | A
-| ------------- | ---
-| Bugfix?       | ✔️/❌
-| Breaks BC?    | ✔️/❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
-| New feature?  | ✔️/❌ <!-- please update "Other Features" section in CHANGELOG.md file -->
-| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
-| Docs PR       | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->
+| Q            | A                                                                                                                       |
+|--------------|-------------------------------------------------------------------------------------------------------------------------|
+| Bugfix?      | ✔️/❌                                                                                                                    |
+| Breaks BC?   | ✔️/❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->                                           |
+| New feature? | ✔️/❌ <!-- please update "Other Features" section in CHANGELOG.md file -->                                               |
+| Issues       | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead --> |
+| Docs PR      | spiral/docs#... <!-- prefix each issue number with "spiral/docs#", required only for new features -->                   |
 
 <!-- Please, replace this notice by a short description of your feature/bugfix.
 This will help people understand your PR and can be used as a start for the documentation. -->

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -28,7 +28,7 @@ class Environment implements EnvironmentInterface
 
     public function getMode(): string
     {
-        return $this->get('RR_MODE', '');
+        return $this->get('RR_MODE');
     }
 
     public function getRelayAddress(): string
@@ -43,7 +43,7 @@ class Environment implements EnvironmentInterface
 
     public function getVersion(): string
     {
-        return $this->get('RR_VERSION', '');
+        return $this->get('RR_VERSION');
     }
 
     /**

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -9,9 +9,10 @@ use Spiral\RoadRunner\Environment\Mode;
 /**
  * @psalm-import-type ModeType from Mode
  * @psalm-type EnvironmentVariables = array{
- *      RR_MODE?:   ModeType|string,
- *      RR_RELAY?:  string,
- *      RR_RPC?:    string,
+ *      RR_MODE?:    ModeType|string,
+ *      RR_RELAY?:   string,
+ *      RR_RPC?:     string,
+ *      RR_VERSION?: string,
  * }|array<string, string>
  * @see Mode
  */
@@ -38,6 +39,11 @@ class Environment implements EnvironmentInterface
     public function getRPCAddress(): string
     {
         return $this->get('RR_RPC', 'tcp://127.0.0.1:6001');
+    }
+
+    public function getVersion(): string
+    {
+        return $this->get('RR_VERSION', '');
     }
 
     /**

--- a/src/EnvironmentInterface.php
+++ b/src/EnvironmentInterface.php
@@ -12,6 +12,7 @@ use Spiral\RoadRunner\Environment\Mode;
  *
  * @psalm-import-type ModeType from Mode
  * @see Mode
+ * @method string getVersion()
  */
 interface EnvironmentInterface
 {
@@ -32,9 +33,4 @@ interface EnvironmentInterface
      * RPC address.
      */
     public function getRPCAddress(): string;
-
-    /**
-     * Roadrunner version
-     */
-    public function getVersion(): string;
 }

--- a/src/EnvironmentInterface.php
+++ b/src/EnvironmentInterface.php
@@ -32,4 +32,9 @@ interface EnvironmentInterface
      * RPC address.
      */
     public function getRPCAddress(): string;
+
+    /**
+     * Roadrunner version
+     */
+    public function getVersion(): string;
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -276,11 +276,10 @@ class Worker implements StreamWorkerInterface
         );
     }
 
-    private function sendProcessId(): static
+    private function sendProcessId(): void
     {
         $frame = new Frame($this->encode(['pid' => \getmypid()]), [], Frame::CONTROL);
         $this->sendFrame($frame);
-        return $this;
     }
 
     private function haveToPing(): void

--- a/tests/Unit/EnvironmentTest.php
+++ b/tests/Unit/EnvironmentTest.php
@@ -45,15 +45,23 @@ final class EnvironmentTest extends TestCase
         $this->assertEquals('rpc_value', $env->getRPCAddress());
     }
 
+    public function testGetVersionWithValue(): void
+    {
+        $env = new Environment(['RR_VERSION' => '2024.1.3']);
+        $this->assertEquals('2024.1.3', $env->getVersion());
+    }
+
     public function testFromGlobals(): void
     {
         $_ENV['RR_MODE'] = 'global_mode';
         $_SERVER['RR_RELAY'] = 'global_relay';
+        $_SERVER['RR_VERSION'] = 'global_version';
 
         $env = Environment::fromGlobals();
 
         $this->assertEquals('global_mode', $env->getMode());
         $this->assertEquals('global_relay', $env->getRelayAddress());
+        $this->assertEquals('global_version', $env->getVersion());
         $this->assertEquals('tcp://127.0.0.1:6001', $env->getRPCAddress());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    |❌
| New feature?  | ✔️
| Issues        |  ❌
| Docs PR       | [RR docs](https://docs.roadrunner.dev/docs/php-worker/environment#default-env-variables-in-php-workers)

Roadrunner has `RR_VERSION` env variable, so let's add it to Environment class like other `RR_*` variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a method to retrieve the Roadrunner version from environment variables.

- **Bug Fixes**
  - Improved table formatting in issue and pull request templates for better readability.

- **Tests**
  - Introduced new test methods to ensure the correct functionality of the version retrieval method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->