### PR TITLE
fixed PHP 8.4 deprecations

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -118,12 +118,12 @@ class Worker implements StreamWorkerInterface
         $this->send('', $this->encode(['stop' => true]));
     }
 
-    public function hasPayload(string $class = null): bool
+    public function hasPayload(?string $class = null): bool
     {
         return $this->findPayload($class) !== null;
     }
 
-    public function getPayload(string $class = null): ?Payload
+    public function getPayload(?string $class = null): ?Payload
     {
         $pos = $this->findPayload($class);
         if ($pos === null) {
@@ -140,7 +140,7 @@ class Worker implements StreamWorkerInterface
      *
      * @return null|int Index in {@see $this->payloads} or null if not found
      */
-    private function findPayload(string $class = null): ?int
+    private function findPayload(?string $class = null): ?int
     {
         // Find in existing payloads
         if ($this->payloads !== []) {

--- a/src/WorkerInterface.php
+++ b/src/WorkerInterface.php
@@ -51,7 +51,7 @@ interface WorkerInterface
      *
      * @return bool Returns {@see true} if worker is ready to accept new payload.
      */
-    public function hasPayload(string $class = null): bool;
+    public function hasPayload(?string $class = null): bool;
 
     /**
      * @param class-string<Payload>|null $class
@@ -59,5 +59,5 @@ interface WorkerInterface
      * @return Payload|null Returns {@see null} if worker is not ready to accept new payload and has no cached payload
      *         of the given type.
      */
-    public function getPayload(string $class = null): ?Payload;
+    public function getPayload(?string $class = null): ?Payload;
 }


### PR DESCRIPTION
| Q            | A                                                                                                                       |
|--------------|-------------------------------------------------------------------------------------------------------------------------|
| Bugfix?      | ✔️                                                                                                                    |
| Breaks BC?   | ❌                                      |
| New feature? | ❌                     

Got rid of deprecations like following:

Deprecated: Spiral\RoadRunner\Worker::hasPayload(): Implicitly marking parameter $class as nullable is deprecated, the explicit nullable type must be used instead in app/vendor/spiral/roadrunner-worker/src/Worker.php on line 121

My gRPC service does not run because of these deprecations. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in payload handling by allowing nullable string parameters in key methods of the Worker class and interface.
  
- **Bug Fixes**
	- Improved type hinting for method parameters in the Worker class and interface, ensuring clearer expectations for input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->